### PR TITLE
[feature] TimerUseCase 분리

### DIFF
--- a/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCase.swift
+++ b/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCase.swift
@@ -17,15 +17,24 @@ protocol PomoTodoUseCase {
   /// - Returns: 오늘 날짜의 `PomoDay`
   func getTodayPomoDay() -> PomoDay
   
-  /// 특정 타이머 프리셋에 따라 `tagTimeRecord`를 추가하는 메서드
+  /// `tagTimeRecord`를 추가하는 메서드
   /// - Parameters:
-  ///   - presetIndex: 타이머 프리셋의 인덱스
-  ///   - todayPomoDay: 오늘의 `PomoDay`
+  ///   - todayPomoDay: 업데이트할 오늘의 `PomoDay`
   ///   - tagTimeRecord: 추가할 `TagTimeRecord`
   func addTagTimeRecords(
-    presetIndex: Int,
     todayPomoDay: PomoDay,
     tagTimeRecord: TagTimeRecord
+  )
+  
+  /// `PomoDay`의 `tomatoCnt`와 `cycleCnt` 값을 설정하는 메서드
+  /// - Parameters:
+  ///   - todayPomoDay: 업데이트할 오늘의 `PomoDay`
+  ///   - tomatoCnt: 설정할 토마토 개수
+  ///   - cycleCnt: 설정할 사이클 비율
+  func setTomatoAndCycle(
+    todayPomoDay: PomoDay,
+    tomatoCnt: Int,
+    cycleCnt: Double
   )
   
   // MARK: - StatsUseCase

--- a/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCaseImpl.swift
+++ b/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCaseImpl.swift
@@ -41,29 +41,38 @@ final class PomoTodoUseCaseImpl: PomoTodoUseCase {
   
   
   func addTagTimeRecords(
-    presetIndex: Int,
     todayPomoDay: PomoDay,
     tagTimeRecord: TagTimeRecord
   ) {
     print("Impl:", #function)
     
     let newRecords = todayPomoDay.tagTimeRecords + [tagTimeRecord]
+    let updatedPomoDay = PomoDay(
+      date: todayPomoDay.date,
+      tomatoCnt: todayPomoDay.tomatoCnt,
+      cycleCnt: todayPomoDay.cycleCnt,
+      tagTimeRecords: newRecords,
+      todos: todayPomoDay.todos
+    )
+    pomoDayRepository.updatePomoDay(updatedPomoDay)
     
-    let result = appConfigRepository.fetchPomoTimer(index: presetIndex)
-    switch result {
-    case .success(let pomoTimer):
-      let tomatoPerCycle = Double(pomoTimer.tomatoPerCycle)
-      let updatedPomoDay = PomoDay(
-        date: todayPomoDay.date,
-        tomatoCnt: todayPomoDay.tomatoCnt + 1,
-        cycleCnt: todayPomoDay.cycleCnt + (1 / tomatoPerCycle),
-        tagTimeRecords: newRecords,
-        todos: todayPomoDay.todos
-      )
-      pomoDayRepository.updatePomoDay(updatedPomoDay)
-    case .failure(let error):
-      print(error)
-    }
+  }
+  
+  func setTomatoAndCycle(
+    todayPomoDay: PomoDay,
+    tomatoCnt: Int,
+    cycleCnt: Double
+  ) {
+    print("Impl:", #function)
+    
+    let updatedPomoDay = PomoDay(
+      date: todayPomoDay.date,
+      tomatoCnt: tomatoCnt,
+      cycleCnt: cycleCnt,
+      tagTimeRecords: todayPomoDay.tagTimeRecords,
+      todos: todayPomoDay.todos
+    )
+    pomoDayRepository.updatePomoDay(updatedPomoDay)
   }
   
   func getAllPomoDays() -> [PomoDay] {

--- a/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCaseImpl.swift
+++ b/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCaseImpl.swift
@@ -46,15 +46,22 @@ final class PomoTodoUseCaseImpl: PomoTodoUseCase {
   ) {
     print("Impl:", #function)
     
-    let newRecords = todayPomoDay.tagTimeRecords + [tagTimeRecord]
-    let updatedPomoDay = PomoDay(
-      date: todayPomoDay.date,
-      tomatoCnt: todayPomoDay.tomatoCnt,
-      cycleCnt: todayPomoDay.cycleCnt,
-      tagTimeRecords: newRecords,
-      todos: todayPomoDay.todos
-    )
-    pomoDayRepository.updatePomoDay(updatedPomoDay)
+    let result = pomoDayRepository.fetchPomoDay(date: todayPomoDay.date)
+    switch result {
+    case .success(let pomoDay):
+      guard let pomoDay else { return }
+      let newRecords = pomoDay.tagTimeRecords + [tagTimeRecord]
+      let updatedPomoDay = PomoDay(
+        date: pomoDay.date,
+        tomatoCnt: pomoDay.tomatoCnt,
+        cycleCnt: pomoDay.cycleCnt,
+        tagTimeRecords: newRecords,
+        todos: pomoDay.todos
+      )
+      pomoDayRepository.updatePomoDay(updatedPomoDay)
+    case .failure(let error):
+      print(error)
+    }
     
   }
   
@@ -65,14 +72,21 @@ final class PomoTodoUseCaseImpl: PomoTodoUseCase {
   ) {
     print("Impl:", #function)
     
-    let updatedPomoDay = PomoDay(
-      date: todayPomoDay.date,
-      tomatoCnt: tomatoCnt,
-      cycleCnt: cycleCnt,
-      tagTimeRecords: todayPomoDay.tagTimeRecords,
-      todos: todayPomoDay.todos
-    )
-    pomoDayRepository.updatePomoDay(updatedPomoDay)
+    let result = pomoDayRepository.fetchPomoDay(date: todayPomoDay.date)
+    switch result {
+    case .success(let pomoDay):
+      guard let pomoDay else { return }
+      let updatedPomoDay = PomoDay(
+        date: pomoDay.date,
+        tomatoCnt: tomatoCnt,
+        cycleCnt: cycleCnt,
+        tagTimeRecords: pomoDay.tagTimeRecords,
+        todos: pomoDay.todos
+      )
+      pomoDayRepository.updatePomoDay(updatedPomoDay)
+    case .failure(let error):
+      print(error)
+    }
   }
   
   func getAllPomoDays() -> [PomoDay] {

--- a/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCaseImpl.swift
+++ b/PomoTodo/PomoTodo/Sources/Domain/UseCase/PomoTodoUseCaseImpl.swift
@@ -174,6 +174,6 @@ enum DefaultPreset {
     Tag(index: 0, name: "공부", colorId: 0),
     Tag(index: 1, name: "운동", colorId: 1),
     Tag(index: 2, name: "독서", colorId: 2),
-    Tag(index: 3, name: "휴식", colorId: 3)
+    Tag(index: 3, name: "취미", colorId: 3)
   ]
 }

--- a/PomoTodo/PomoTodo/Sources/Views/MainTabBarView.swift
+++ b/PomoTodo/PomoTodo/Sources/Views/MainTabBarView.swift
@@ -45,7 +45,6 @@ struct MainTabBarView: View {
     .tint(.indigoNormal)
     .onAppear {
       setupTabBarAppearance()
-      let _ = container.pomoTodoUseCase.getTodayPomoDay()
     }
   }
   


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
@doyeonk429과 상의하여 TimerUseCase 분리하였습니다.

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #33 

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->
두개로 분리한 UseCase는 다음과 같습니다.
```swift
  /// `tagTimeRecord`를 추가하는 메서드
  /// - Parameters:
  ///   - todayPomoDay: 업데이트할 오늘의 `PomoDay`
  ///   - tagTimeRecord: 추가할 `TagTimeRecord`
  func addTagTimeRecords(
    todayPomoDay: PomoDay,
    tagTimeRecord: TagTimeRecord
  )
  ```
PomoDay의 모델에서 `[tagTimeRecord]`의 총 시간을 계산하는 속성을
이미 가지고 있기 때문에 `tagtimeRecord`만 이 usecase를 통해 추가하면 하루의 총 누적시간은 알아서 계산되어 들어갑니다.

@doyeonk429 님과 협의한 내용에 따라 tomato에 관련된 정보를 set하는 메서드를 따로 만들었습니다.
```swift
  /// `PomoDay`의 `tomatoCnt`와 `cycleCnt` 값을 설정하는 메서드
  /// - Parameters:
  ///   - todayPomoDay: 업데이트할 오늘의 `PomoDay`
  ///   - tomatoCnt: 설정할 토마토 개수
  ///   - cycleCnt: 설정할 사이클 비율
  func setTomatoAndCycle(
    todayPomoDay: PomoDay,
    tomatoCnt: Int,
    cycleCnt: Double
  )
```

+ 태그 프리셋 휴식 -> 운동으로 변경
